### PR TITLE
Revert "Update build-audit GA to workaround checkout #672"

### DIFF
--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -26,7 +26,7 @@ jobs:
         hugo: ["0.80.0", "0.88.1", "latest"]
     steps:
       - name: "Build Site with Hugo and Audit"
-        uses: danielfdickinson/build-audit-action-hugo-dfd@v0.1.2
+        uses: danielfdickinson/build-audit-action-hugo-dfd@v0.1.1
         with:
           hugo-version: ${{ matrix.hugo }}
           upload-site-as: unminified-site-${{ matrix.hugo }}


### PR DESCRIPTION
This reverts commit 62c099d7b8960a047a26fd097f5c8f70ad2d56dc.
The GitHub checkout/actions issue #672 has been resolved and the
workaround is no longer require.d