### PR TITLE
Escape shortcodes examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,19 @@ All params may be set at the site or per-page level.
 
 **NB** You can't mix positional (unnamed) parameters with named parameters, so the first two examples will only work when the only parameter is a the destination.
 
-``{{< link-special "/path/to/an/internal/destination" >}}link text{{< /link-special >}}`` (external destinations are also valid).
+``{{\< link-special "/path/to/an/internal/destination" >}}link text{{\< /link-special >}}`` (external destinations are also valid).
 
 OR
 
-``{{< link-special "/path/to/an/internal/destination" />}}`` (external destinations are also valid).
+``{{\< link-special "/path/to/an/internal/destination" />}}`` (external destinations are also valid).
 
 OR
 
-``{{< link-special href="/path/to/an/internal/destination" >}}link text{{< /link-special >}}`` (external destinations are also valid).
+``{{\< link-special href="/path/to/an/internal/destination" >}}link text{{\< /link-special >}}`` (external destinations are also valid).
 
 OR
 
-``{{< link-special href="/path/to/an/internal/destination" />}}`` (external destinations are also valid).
+``{{\< link-special href="/path/to/an/internal/destination" />}}`` (external destinations are also valid).
 
 #### Other Parameters for the Shortcode
 


### PR DESCRIPTION
Due to the feature of .RenderString in Hugo 0.100.0 which does not yet honour code
(inline) blocks the way they are in the main .Content.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>